### PR TITLE
Allow gnome-shell 3.14 compat

### DIFF
--- a/timer@olebowle.gmx.com/metadata.json
+++ b/timer@olebowle.gmx.com/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.20"],
+    "shell-version": ["3.20, 3.14"],
     "uuid": "timer@olebowle.gmx.com",
     "name": "Timer",
     "url": "https://github.com/olebowle/gnome-shell-timer",


### PR DESCRIPTION
Fixes #31 on Vanilla Debian 8 Jessie running Gnome 3.14.4. Someone will need to check compatibility with other shell versions before pushing to the official Debian repo.
