### PR TITLE
Added italian translation.

### DIFF
--- a/po/it_IT/gnome-shell-timer.po
+++ b/po/it_IT/gnome-shell-timer.po
@@ -1,0 +1,46 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-shell-timer\n"
+"POT-Creation-Date: 2017-03-23 22:56+0100\n"
+"PO-Revision-Date: 2017-03-23 22:57+0100\n"
+"Last-Translator: Mauro Scomparin <scompo@gmail.com>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "Schema \"%s\" not found."
+msgstr "Schema \"%s\" non trovato."
+
+msgid "Run Timer"
+msgstr "Avvia Timer"
+
+msgid "Reset Timer"
+msgstr "Azzera Timer"
+
+msgid "Restart Timer"
+msgstr "Riavvia Timer"
+
+msgid "Set Timer"
+msgstr "Imposta Timer"
+
+msgid "Preferences..."
+msgstr "Preferenze..."
+
+msgid "Timer finished!"
+msgstr "Timer terminato!"
+
+msgid "Close"
+msgstr "Chiudi"
+
+msgid "Hours"
+msgstr "Ore"
+
+msgid "Minutes"
+msgstr "Minuti"
+
+msgid "Seconds"
+msgstr "Secondi"
+
+msgid "Preset \"%s\" finished!"
+msgstr "Programmazione \"%s\" terminata!"


### PR DESCRIPTION
Hi, I've provided the Italian translation for the strings present in the `/po/gnome-shell-timer.pot` file.
I've tested it in my fedora 25 system with it_IT locale and it looks fine.