### PR TITLE
Document new location for gnome-shell-timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,6 @@
-# Timer extension for gnome-shell
-- Provides a countdown timer in the gnome-shell top panel
-- User adjustable timer presets for common tasks
-- Manually adjustable timer
+# Extension is unmaintained
 
-# Installation
-## Archlinux
-Get from [AUR](https://aur.archlinux.org/packages.php?ID=52047)
+This extension is no longer maintained by myself (Ole Ernst).
 
-## Debian
-Get from [Debian Packages](http://packages.debian.org/sid/gnome-shell-timer)
-
-## Direct from source
-- Get Source
-    * for older versions see [releases](https://github.com/olebowle/gnome-shell-timer/releases)
-    * [master branch](https://github.com/olebowle/gnome-shell-timer/zipball/master)
-
-- use the provided [make.sh](https://github.com/olebowle/gnome-shell-timer/blob/master/make.sh) script du (un)install the extension
-- Enable the extension using gnome-tweak-tool
-- Press *Alt + F2*, and *r* in command to restart gnome-shell
-
-# Configuration
-- Please refer to the Wiki:
-    * [Gnome-shell 3.x](https://github.com/olebowle/gnome-shell-timer/wiki/Configuration-3.x)
-    * [Gnome-shell 3.0](https://github.com/olebowle/gnome-shell-timer/wiki/Configuration-3.0)
-
-# License
-See [COPYING](https://github.com/olebowle/gnome-shell-timer/blob/master/COPYING) for details.
-
-# Thanks
-- Contributors: [gnome-shell-pomodoro](https://github.com/codito/gnome-shell-pomodoro/contributors) which was a nice starting point for this extension (code and documentation)
-- Contributors: [gnome-shell-system-monitor-applet](https://github.com/paradoxxxzero/gnome-shell-system-monitor-applet/contributors) - pie diagram
-- [Timer Applet](https://launchpad.net/timer-applet) - original idea
+You might want to look into better maintained alternatives:
+https://github.com/blackjackshellac/kitchenTimer


### PR DESCRIPTION
I decided to step up to maintain a repository where I will process the contributions to keep the extension working with future GNOME releases. It would be nice if you could merge this so that users are redirected to a place where there's a version of gnome-shell-timer that works with the latest GNOME releases.